### PR TITLE
[refactoring] - kosmo datasources config handler

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,4 +9,6 @@ jobs:
     - name: PyLint with dynamic badge
       uses: Silleellie/pylint-github-action@v2
       with:
-        lint-path: main.py
+        lint-path: |
+          datasources
+          main.py

--- a/LEARNING-STEPS.md
+++ b/LEARNING-STEPS.md
@@ -1,3 +1,14 @@
+### Objetivo 3
+#### Refatorar o código existente, implementando Clean Code
+- Espera-se que a maioria da codebase siga princípios estabelecidos de Clean Code e Design Patterns
+- Espera-se que a codebase siga o PEP8 Style Guide
+- Espera-se que o refactor seja explicado via Pull Request
+
+1. **config**
+   1. ✅ Refatorando a parte de config para que o app suporte várias fontes de dados. 
+   2. ⏳ Adicionar try catch e tratar erros na validação do arquivo de configuração
+   3. ⏳ Testes
+
 ### Objetivo 2 :heavy_check_mark:
 
 ##### Plotar a distância em anos luz das estrelas num gráfico 3D

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # kosmoplot 🌌 🔭 
 
-![pylint](https://img.shields.io/badge/PyLint-5.45-orange?logo=python&logoColor=white)
+![pylint](https://img.shields.io/badge/PyLint-6.50-orange?logo=python&logoColor=white)
 
 **kosmoplot** is a little python application that generates a 3D view of stars constellations.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # kosmoplot 🌌 🔭 
 
-![pylint](https://img.shields.io/badge/PyLint-5.73-orange?logo=python&logoColor=white)
+![pylint](https://img.shields.io/badge/PyLint-5.96-orange?logo=python&logoColor=white)
 
 **kosmoplot** is a little python application that generates a 3D view of stars constellations.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # kosmoplot 🌌 🔭 
 
-![pylint](https://img.shields.io/badge/PyLint-0.00-red?logo=python&logoColor=white)
+![pylint](https://img.shields.io/badge/PyLint-5.45-orange?logo=python&logoColor=white)
 
 **kosmoplot** is a little python application that generates a 3D view of stars constellations.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # kosmoplot 🌌 🔭 
 
-![pylint](https://img.shields.io/badge/PyLint-6.50-orange?logo=python&logoColor=white)
+![pylint](https://img.shields.io/badge/PyLint-6.61-orange?logo=python&logoColor=white)
 
 **kosmoplot** is a little python application that generates a 3D view of stars constellations.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # kosmoplot 🌌 🔭 
 
-![pylint](https://img.shields.io/badge/PyLint-5.96-orange?logo=python&logoColor=white)
+![pylint](https://img.shields.io/badge/PyLint-0.00-red?logo=python&logoColor=white)
 
 **kosmoplot** is a little python application that generates a 3D view of stars constellations.
 

--- a/datasources.ini
+++ b/datasources.ini
@@ -1,0 +1,21 @@
+[ninja-api]
+type = REST
+endpoint = https://api.api-ninjas.com/v1
+api_key = j5oevuOJ9NdcM1HwWsOFpg==75r5iUoUJbh8BF33
+http_verb = GET
+headers = {"limit": "30"}
+resource = stars
+
+[star universe catallogue]
+type = SOAP
+http_verb = POST
+endpoint = https://xml.api-ninjas.com/v1
+
+[csv file from maxstarsite.io]
+type = CSV
+key2 = value
+
+[star universe catallogue PLUS]
+type = SOAP
+http_verb = POST
+endpoint = https://xml.api-ninjas.com/v1

--- a/datasources/datasources.py
+++ b/datasources/datasources.py
@@ -33,3 +33,4 @@ class DataSourceConfig:
             if not self.config.has_option(self.section, key):
                 print(key)
                 return False
+            return True

--- a/datasources/datasources.py
+++ b/datasources/datasources.py
@@ -1,0 +1,37 @@
+from abc import ABC, abstractmethod
+import configparser
+
+class DataSourceConfig:
+    # Load the config ini file, if it exists
+    def __init__(self, config_file):
+        self.config = configparser.ConfigParser()
+        self.config.read(config_file)
+    
+    def get_config(self):
+        return self.config
+
+    def get_types(self, type):
+        ds_rest_list = [ds for ds in self.config.sections() if (self.config.get(ds, "type") == type)]
+        return ds_rest_list
+
+class DataSourceConfigValidator(ABC):
+    def __init__(self, data_source_type) -> None:
+        self.data_source_type = data_source_type
+
+    @abstractmethod
+    def validate_datasource_config(self):
+        pass
+
+class ValidatorRest(DataSourceConfigValidator):
+    def __init__(self) -> None:
+        super().__init__("rest")
+        self.keys_to_validate = ["endpoint","http_verb","resource"]
+        
+    def validate_datasource_config(self, section, config):
+        self.section = section
+        self.config = config
+        for key in self.keys_to_validate:
+            if not self.config.has_option(self.section, key):
+                print(key)
+                return False
+        return True

--- a/datasources/datasources.py
+++ b/datasources/datasources.py
@@ -1,37 +1,35 @@
-from abc import ABC, abstractmethod
+"""Module providing classess to construct data sources"""
+
 import configparser
 
+config = configparser.ConfigParser()
+config.read("datasources.ini")
+
 class DataSourceConfig:
-    # Load the config ini file, if it exists
-    def __init__(self, config_file):
-        self.config = configparser.ConfigParser()
-        self.config.read(config_file)
-    
-    def get_config(self):
-        return self.config
+    """Class representing a section of a datasource config"""
 
-    def get_types(self, type):
-        ds_rest_list = [ds for ds in self.config.sections() if (self.config.get(ds, "type") == type)]
-        return ds_rest_list
-
-class DataSourceConfigValidator(ABC):
-    def __init__(self, data_source_type) -> None:
-        self.data_source_type = data_source_type
-
-    @abstractmethod
-    def validate_datasource_config(self):
-        pass
-
-class ValidatorRest(DataSourceConfigValidator):
-    def __init__(self) -> None:
-        super().__init__("rest")
-        self.keys_to_validate = ["endpoint","http_verb","resource"]
-        
-    def validate_datasource_config(self, section, config):
+    def __init__(self, datasource_config, section = None, keys_to_validate = None) -> None:
+        self.type = None
+        self.keys_to_validate = keys_to_validate
         self.section = section
-        self.config = config
+        self.config = datasource_config
+        self.datasource_config = self.config[self.section]
+
+    def get_type(self):
+        """Returns the datasource type of the given section"""
+        return self.section.get("type")
+
+    def set_section(self, section):
+        """Set the section of the object"""
+        self.section = section
+
+    def set_keys_to_validate(self, keys) -> list:
+        """Set the keys (as a list) to validate agains section"""
+        self.keys_to_validate = keys
+
+    def validate(self):
+        """Validates the givens keys agains section"""
         for key in self.keys_to_validate:
             if not self.config.has_option(self.section, key):
                 print(key)
                 return False
-        return True

--- a/main.py
+++ b/main.py
@@ -9,9 +9,7 @@ import datasources.datasources as ds
 session = requests.Session
 
 def fetch_stardata(config):
-    #url = "https://api.api-ninjas.com/v1/stars"
     url = config.get("ninja-api", "endpoint") + "/" + config.get("ninja-api", "resource")
-    #api_key = "j5oevuOJ9NdcM1HwWsOFpg==75r5iUoUJbh8BF33"
     api_key = config.get("ninja-api", "api_key")
     offset = 0
     limit = 30
@@ -36,9 +34,6 @@ def enrich_stardata(raw_data):
     for i in raw_data:
         i.update({"declination": i["declination"].replace(u"\u00a0", " ")})
         i.update({"apparent_magnitude": i["apparent_magnitude"].replace(u"\u2212", "-")})
-        print(i["right_ascension"])
-        print(i["declination"])
-        print(i["apparent_magnitude"])
         enriched_data.append(i)
     return enriched_data
 
@@ -221,14 +216,8 @@ for section in ds_config.get_types("REST"):
         print("valid rest")
     else:
         print("invalid rest")
-    #data_api.read_config()
-    #get_stardata()
-    #plot_stars_3d()
 
 raw_star_data = fetch_stardata(config)
 enriched_star_data = enrich_stardata(raw_star_data)
 plot_stars_3d(enriched_star_data)
 
-
-#while True:
-#    time.sleep(10)

--- a/main.py
+++ b/main.py
@@ -2,9 +2,8 @@ import json
 import requests
 import matplotlib.pyplot as plt
 import astropy.units as u
-from astropy.coordinates import SkyCoord
-import time
 import datasources.datasources as ds
+from astropy.coordinates import SkyCoord
 
 session = requests.Session
 
@@ -207,17 +206,8 @@ def plot_stars_3d(data):
 #            params = {""}
 
 #def main():
-ds_config = ds.DataSourceConfig("datasources.ini")
-config = ds_config.get_config()
-ds_config_rest = ds.ValidatorRest()
 
-for section in ds_config.get_types("REST"):
-    if ds_config_rest.validate_datasource_config(section, ds_config.get_config()):
-        print("valid rest")
-    else:
-        print("invalid rest")
-
-raw_star_data = fetch_stardata(config)
+raw_star_data = fetch_stardata(ds.config)
 enriched_star_data = enrich_stardata(raw_star_data)
 plot_stars_3d(enriched_star_data)
 


### PR DESCRIPTION
## Refactoring - datasources
In the ugly original script, there is not a usage of a _config file_, so this pull request adds the `ConfigParser` module.
The module is used by some _Classes_ to handle config loader and **validation** of every section.
I tried to write Classes following the **SOLID** principles, specially the _"Single Responsibility"_ and _"Open Closed"_.
The idea is that I can add **different data sources** of stars around the internet, and for each type (eg. api rest or soap, csv file, etc) to collect raw data to enrich later.

Please fell free to comment and help me to write a Clean Python Code. :) 